### PR TITLE
Added configurations for OSX/Viscosity

### DIFF
--- a/include/html/form/configuration.php
+++ b/include/html/form/configuration.php
@@ -22,6 +22,7 @@
           <label for="configuration_os">OS</label>
           <select name="configuration_os" id="configuration_os" class="form-control">
             <option value="gnu_linux">GNU/Linux</option>
+            <option value="osx_viscosity">OSX/Viscosity</option>
             <option value="windows">Windows</option>
           </select>
         </div>

--- a/index.php
+++ b/index.php
@@ -23,8 +23,9 @@
       // Thanks http://stackoverflow.com/questions/4914750/how-to-zip-a-whole-folder-using-php
       if($_POST['configuration_os'] == "gnu_linux") {
         $conf_dir = 'gnu-linux';
-      }
-      else {
+      } elseif($_POST['configuration_os'] == "osx_viscosity") {
+        $conf_dir = 'osx-viscosity';
+      } else {
         $conf_dir = 'windows';
       }
       $rootPath = realpath("./client-conf/$conf_dir");

--- a/install.sh
+++ b/install.sh
@@ -228,10 +228,12 @@ sed -i "s/\$pass = '';/\$pass = '$mysql_pass';/" "./include/config.php"
 
 # Replace in the client configurations with the ip of the server
 sed -i "s/remote xxx\.xxx\.xxx\.xxx 443/remote $ip_server $server_port/" "./client-conf/gnu-linux/client.conf"
+sed -i "s/remote xxx\.xxx\.xxx\.xxx 443/remote $ip_server $server_port/" "./client-conf/osx-viscosity/client.conf"
 sed -i "s/remote xxx\.xxx\.xxx\.xxx 443/remote $ip_server $server_port/" "./client-conf/windows/client.ovpn"
 
 # Copy ta.key inside the client-conf directory
 cp "/etc/openvpn/"{ca.crt,ta.key} "./client-conf/gnu-linux/"
+cp "/etc/openvpn/"{ca.crt,ta.key} "./client-conf/osx-viscosity/"
 cp "/etc/openvpn/"{ca.crt,ta.key} "./client-conf/windows/"
 
 # Install third parties

--- a/installation/client-conf/osx-viscosity/client.conf
+++ b/installation/client-conf/osx-viscosity/client.conf
@@ -1,0 +1,26 @@
+client
+dev tun
+proto tcp-client
+remote xxx.xxx.xxx.xxx 443
+resolv-retry infinite
+cipher AES-256-CBC
+redirect-gateway
+
+# Keys
+# Identity
+ca ca.crt
+tls-auth ta.key 1
+key-direction 1
+remote-cert-tls server
+auth-user-pass
+auth-nocache
+
+# Security
+nobind
+persist-key
+persist-tun
+comp-lzo
+verb 3
+
+# Proxy ?
+# http-proxy cache.univ.fr 3128


### PR DESCRIPTION
Was missing the config for Viscosity on OSX.
The linux config works after removing the update-resolv.sh.
Viscosity will accept the openvpn servers push for dns servers.