### PR TITLE
set default easy rsa version in case github api rate limit exceeded

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -123,7 +123,12 @@ EASYRSA_RELEASES=( $(
   awk '{ print $2 }' | \
   sed 's/[,|"|v]//g'
 ) )
+
 EASYRSA_LATEST=${EASYRSA_RELEASES[0]}
+
+if [[ ! -z $EASYRSA_LATEST ]]; then
+  EASYRSA_LATEST=3.0.5
+fi
 
 # Get the rsa keys
 wget -q https://github.com/OpenVPN/easy-rsa/releases/download/v${EASYRSA_LATEST}/EasyRSA-nix-${EASYRSA_LATEST}.tgz


### PR DESCRIPTION
In case the following message appears when accessing the github api
```
{
  "message": "API rate limit exceeded for 45.255.126.165. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://developer.github.com/v3/#rate-limiting"
}
```