### PR TITLE
Fix Debian 9 prerequisite instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ Administrate its OpenVPN with a web interface (logs visualisations, users managi
 
 ### Debian 9 Stretch
 
+In order to install `npm`, [stretch-backports need to be added to your sources.list](https://backports.debian.org/Instructions/#index2h2).
+
 ````
-# apt-get install openvpn apache2 php-mysql mysql-server php-zip php nodejs unzip git wget sed npm curl
+# apt-get install -t stretch-backports npm nodejs
+# apt-get install openvpn apache2 php-mysql mysql-server php-zip php unzip git wget sed curl
 # npm install -g bower
-# ln -s /usr/bin/nodejs /usr/bin/node
 ````
 
 ### CentOS 7


### PR DESCRIPTION
The current installation Debian 9 instructions are not working (anynmore?). This PR fixes the issues.

- npm is only available via stretch-backports
- new npm depends on a newer version of nodejs from stretch-backports
- Symlinking nodejs to node is not required anymore