### PR TITLE
Passthrough 10.0.0.0/8

### DIFF
--- a/installation/server.conf
+++ b/installation/server.conf
@@ -25,6 +25,26 @@ cipher AES-256-CBC
 # Subnetwork, the server will be the 10.8.0.1 and clients will take the other ips
 server 10.8.0.0 255.255.255.0
 
+# Pass-through all private IPs that do not belong to the our subnetwork so that it doesn't pass through the OpenVPN server
+# This allows the client to access something like 10.27.0.1 without client reconfig as this is still a valid intranet IP.
+push "route 10.0.0.0 255.248.0.0 net_gateway"
+push "route 10.8.1.0 255.255.255.0 net_gateway"
+push "route 10.8.2.0 255.255.254.0 net_gateway"
+push "route 10.8.4.0 255.255.252.0 net_gateway"
+push "route 10.8.8.0 255.255.248.0 net_gateway"
+push "route 10.8.16.0 255.255.240.0 net_gateway"
+push "route 10.8.32.0 255.255.224.0 net_gateway"
+push "route 10.8.64.0 255.255.192.0 net_gateway"
+push "route 10.8.128.0 255.255.128.0 net_gateway"
+push "route 10.9.0.0 255.255.0.0 net_gateway"
+push "route 10.10.0.0 255.254.0.0 net_gateway"
+push "route 10.12.0.0 255.252.0.0 net_gateway"
+push "route 10.16.0.0 255.240.0.0 net_gateway"
+push "route 10.32.0.0 255.224.0.0 net_gateway"
+push "route 10.64.0.0 255.192.0.0 net_gateway"
+push "route 10.128.0.0 255.128.0.0 net_gateway"
+
+# For the rest 
 # Redirect all IP network traffic originating on client machines to pass through the OpenVPN server
 push "redirect-gateway def1"
 


### PR DESCRIPTION
Fixes an issue that causes the OpenVPN connection to not allow access to other IPs within the 10.0.0.0/8 range, so that only 10.8.0.0/24 will be redirected.